### PR TITLE
Fix for wordcounter in en_GB

### DIFF
--- a/databasic/__init__.py
+++ b/databasic/__init__.py
@@ -19,6 +19,7 @@ VALID_LANGUAGES = ('es', 'en', 'en_GB','en_CY', 'pt', 'da', 'cy')
 NLTK_STOPWORDS_BY_LANGUAGE = {
     'es': 'spanish',
     'en': 'english',
+    'en_GB': 'english',
     'en_CY': 'welsh_english',
     'pt': 'portuguese',
     'da': 'danish',

--- a/databasic/logic/textanalysis.py
+++ b/databasic/logic/textanalysis.py
@@ -17,7 +17,7 @@ def _databasic_tokenize(text, ignore_case=True, remove_stopwords=True, lang='eng
     return [w for w in words if (w not in string.punctuation and w not in stopwordlist)]
 
 def term_document_matrix(texts, current_lang_code):
-    lang = NLTK_STOPWORDS_BY_LANGUAGE[current_lang_code]
+    lang = NLTK_STOPWORDS_BY_LANGUAGE.get(current_lang_code, "english")
     term_doc_matrix = textmining.TermDocumentMatrix(tokenizer=lambda text:_databasic_tokenize(text, lang=lang))
     for t in texts:
         term_doc_matrix.add_doc(t)

--- a/databasic/logic/wtfcsvstat.py
+++ b/databasic/logic/wtfcsvstat.py
@@ -249,7 +249,7 @@ class WTFCSVStat:
             if 'str' in column_info['type'] and not 'most_freq_values' in column_info:
                 # TODO: these results could be cleaned up using textmining
                 # TODO: send in the language properly?
-                stopwords_language = NLTK_STOPWORDS_BY_LANGUAGE[language]
+                stopwords_language = NLTK_STOPWORDS_BY_LANGUAGE.get(language, "english")
                 column_info['word_counts'] = wordhandler.get_word_counts(
                     str([s for s in values]).strip('[]').replace("u'", '').replace("',", ''),
                     True, True, stopwords_language, False, False)

--- a/databasic/views/wordcounter.py
+++ b/databasic/views/wordcounter.py
@@ -213,7 +213,7 @@ def process_upload(doc):
 
 
 def _process_words(words, ignore_case, ignore_stopwords, is_sample):
-    stopwords_language = NLTK_STOPWORDS_BY_LANGUAGE[g.current_lang]
+    stopwords_language = NLTK_STOPWORDS_BY_LANGUAGE.get(g.current_lang, "english")
     counts = wordhandler.get_word_counts(
         words,
         ignore_case,


### PR DESCRIPTION
I found that wordcounter wasn't working because my language was set to en_GB and it wasn't finding the stopwords list.

This PR does two things:

1. Selects the english stopword list for en_GB language
2. Falls back to english stopword list if the language isn't found (this might not be desired behaviour - potentially it's better to fallback to no stopword list at all?)

